### PR TITLE
Pass in computed ref to usePagination

### DIFF
--- a/src/composables/use-array-pagination.js
+++ b/src/composables/use-array-pagination.js
@@ -2,7 +2,7 @@ import usePagination from './use-pagination'
 import { ref, watch } from '@vue/composition-api'
 
 export default function useArrayPagination(arrayRef = ref([])) {
-  const pagination = usePagination(undefined, arrayRef.value.length)
+  const pagination = usePagination(undefined, computed(() => arrayRef.value.length))
 
   const result = ref([])
 


### PR DESCRIPTION
Just skimming through some of the code examples and I suspect the use of `usePagination` is not as intended?

According to
https://github.com/LinusBorg/composition-api-demos/blob/develop/src/composables/use-pagination.js#L5

The second argument should be a ref to a number?